### PR TITLE
Update authorization route

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -32,7 +32,7 @@ module.exports = function (fastify, options) {
   _options.redirect_uri = _options.redirect_uri || (_options.appUrl + _options.handlerPath)
   _options.auth0 = {
     graphUrl: `https://${_options.domain}`,
-    dialogUrl: `https://${_options.domain}/login?response_type=code&scope=${_options.scope}&client=${_options.client_id}&redirect_uri=${_options.redirect_uri}`
+    dialogUrl: `https://${_options.domain}/authorize?response_type=code&scope=${_options.scope}&client_id=${_options.client_id}&redirect_uri=${_options.redirect_uri}`
   }
   return _options
 }


### PR DESCRIPTION
After spending a few hours trying to use this plugin, I eventually managed to figure out that the login route has changed in the last 2 years.

The PR is updating the URL to which users are redirected when not logged in.